### PR TITLE
Update to Java 21 and migrate from javax to jakarta packages

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      PARENT_BRANCH: ${{ github.ref_name == 'master' && 'main' || github.ref_name }}
+      PARENT_BRANCH: main
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - uses: actions/cache@v4
       with:
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: codelibs/fess-parent
-        ref: "14.19.x" # ${{ env.PARENT_BRANCH }}
+        ref: ${{ env.PARENT_BRANCH }}
         path: fess-parent
     - name: Install fess-parent
       run: |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-webapp-mcp</artifactId>
 	<packaging>jar</packaging>
 	<name>MCP Webapp Plugin</name>
-	<version>14.19.0-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-webapp-mcp.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-webapp-mcp.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>14.19.1-SNAPSHOT</version>
+		<version>15.2.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<build>
@@ -63,15 +63,15 @@
 	</repositories>
 	<dependencies>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>${javax.annotation.api.version}</version>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+			<version>${jakarta.annotation.api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>${javax.servlet.api.version}</version>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>${jakarta.servlet.api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
@@ -134,11 +134,17 @@ public class McpApiManager extends BaseApiManager {
 
     protected Map<String, Object> parseRequestBody(final HttpServletRequest request) throws IOException {
         return JsonXContent.jsonXContent
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, request.getInputStream()).map();
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, request.getInputStream())
+                .map();
     }
 
     protected Object dispatchRpcMethod(final String method, final Map<String, Object> params) {
-        return switch(method){case"initialize"->handleInitialize();case"tools/list"->handleListTools();case"tools/call"->handleInvoke(params);default->throw new McpApiException(ErrorCode.MethodNotFound,"Unknown method: "+method);};
+        return switch (method) {
+        case "initialize" -> handleInitialize();
+        case "tools/list" -> handleListTools();
+        case "tools/call" -> handleInvoke(params);
+        default -> throw new McpApiException(ErrorCode.MethodNotFound, "Unknown method: " + method);
+        };
     }
 
     @Override
@@ -210,11 +216,20 @@ public class McpApiManager extends BaseApiManager {
      */
     @SuppressWarnings("unchecked")
     protected Map<String, Object> handleInvoke(final Map<String, Object> params) {
-        final String tool=(String)params.get("name");if(tool==null||tool.isEmpty()){throw new McpApiException(ErrorCode.InvalidParams,"Missing required parameter: name");}
+        final String tool = (String) params.get("name");
+        if (tool == null || tool.isEmpty()) {
+            throw new McpApiException(ErrorCode.InvalidParams, "Missing required parameter: name");
+        }
 
-        final Map<String,Object>toolParams=(Map<String,Object>)params.get("arguments");if(toolParams==null){throw new McpApiException(ErrorCode.InvalidParams,"Missing required parameter: arguments");}return switch(tool){case"search"->invokeSearch(toolParams);
+        final Map<String, Object> toolParams = (Map<String, Object>) params.get("arguments");
+        if (toolParams == null) {
+            throw new McpApiException(ErrorCode.InvalidParams, "Missing required parameter: arguments");
+        }
+        return switch (tool) {
+        case "search" -> invokeSearch(toolParams);
         // TODO Add administrative tools here...
-        default->throw new McpApiException(ErrorCode.InvalidParams,"Unknown tool: "+tool);};
+        default -> throw new McpApiException(ErrorCode.InvalidParams, "Unknown tool: " + tool);
+        };
     }
 
     @SuppressWarnings("unchecked")
@@ -233,7 +248,8 @@ public class McpApiManager extends BaseApiManager {
             public Map<String, String[]> getFields() {
                 final Map<String, Object> fields = (Map<String, Object>) paramMap.get("fields");
                 if (fields != null) {
-                    return fields.entrySet().stream()
+                    return fields.entrySet()
+                            .stream()
                             .collect(Collectors.toMap(Map.Entry::getKey, e -> ((List<String>) e.getValue()).toArray(n -> new String[n])));
                 }
                 return Collections.emptyMap();
@@ -243,8 +259,10 @@ public class McpApiManager extends BaseApiManager {
             public Map<String, String[]> getConditions() {
                 final Map<String, Object> conditions = (Map<String, Object>) paramMap.get("as");
                 if (conditions != null) {
-                    return conditions.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                            e -> ((List<?>) e.getValue()).stream().map(Object::toString).toArray(n -> new String[n])));
+                    return conditions.entrySet()
+                            .stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey,
+                                    e -> ((List<?>) e.getValue()).stream().map(Object::toString).toArray(n -> new String[n])));
                 }
                 return Collections.emptyMap();
             }
@@ -384,8 +402,13 @@ public class McpApiManager extends BaseApiManager {
                         field.getValueCountMap().entrySet().stream().map(e -> Map.of("value", e.getKey(), "count", e.getValue())).toList());
                 return m;
             }).toList());
-            result.put("facet_query", data.getFacetResponse().getQueryCountMap().entrySet().stream()
-                    .map(e -> Map.of("value", e.getKey(), "count", e.getValue())).toList());
+            result.put("facet_query",
+                    data.getFacetResponse()
+                            .getQueryCountMap()
+                            .entrySet()
+                            .stream()
+                            .map(e -> Map.of("value", e.getKey(), "count", e.getValue()))
+                            .toList());
         }
 
         return result;

--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
@@ -16,7 +16,6 @@
 package org.codelibs.fess.plugin.webapp.api.mcp;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -25,12 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import javax.annotation.PostConstruct;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,6 +42,12 @@ import org.dbflute.optional.OptionalThing;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * The {@code McpApiManager} class is responsible for handling JSON-RPC 2.0 API requests
@@ -139,12 +138,7 @@ public class McpApiManager extends BaseApiManager {
     }
 
     protected Object dispatchRpcMethod(final String method, final Map<String, Object> params) {
-        return switch (method) {
-        case "initialize" -> handleInitialize();
-        case "tools/list" -> handleListTools();
-        case "tools/call" -> handleInvoke(params);
-        default -> throw new McpApiException(ErrorCode.MethodNotFound, "Unknown method: " + method);
-        };
+        return switch(method){case"initialize"->handleInitialize();case"tools/list"->handleListTools();case"tools/call"->handleInvoke(params);default->throw new McpApiException(ErrorCode.MethodNotFound,"Unknown method: "+method);};
     }
 
     @Override
@@ -216,20 +210,11 @@ public class McpApiManager extends BaseApiManager {
      */
     @SuppressWarnings("unchecked")
     protected Map<String, Object> handleInvoke(final Map<String, Object> params) {
-        final String tool = (String) params.get("name");
-        if (tool == null || tool.isEmpty()) {
-            throw new McpApiException(ErrorCode.InvalidParams, "Missing required parameter: name");
-        }
+        final String tool=(String)params.get("name");if(tool==null||tool.isEmpty()){throw new McpApiException(ErrorCode.InvalidParams,"Missing required parameter: name");}
 
-        final Map<String, Object> toolParams = (Map<String, Object>) params.get("arguments");
-        if (toolParams == null) {
-            throw new McpApiException(ErrorCode.InvalidParams, "Missing required parameter: arguments");
-        }
-        return switch (tool) {
-        case "search" -> invokeSearch(toolParams);
+        final Map<String,Object>toolParams=(Map<String,Object>)params.get("arguments");if(toolParams==null){throw new McpApiException(ErrorCode.InvalidParams,"Missing required parameter: arguments");}return switch(tool){case"search"->invokeSearch(toolParams);
         // TODO Add administrative tools here...
-        default -> throw new McpApiException(ErrorCode.InvalidParams, "Unknown tool: " + tool);
-        };
+        default->throw new McpApiException(ErrorCode.InvalidParams,"Unknown tool: "+tool);};
     }
 
     @SuppressWarnings("unchecked")
@@ -419,7 +404,7 @@ public class McpApiManager extends BaseApiManager {
         final Map<String, Object> errorResponse = Map.of("jsonrpc", "2.0", "id", id, "error", error);
         try {
             write(JsonXContent.contentBuilder().map(errorResponse).toString(), mimeType, Constants.UTF_8);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             logger.error("Failed to write error response", e);
         }
     }


### PR DESCRIPTION
This pull request performs the following updates:

- Upgrades the JDK version in the GitHub Actions workflow from Java 17 to Java 21.
- Fixes the environment reference to always use main as the parent branch.
- Updates the Maven pom.xml:
  - Changes the project and parent versions from 14.19.x to 15.2.0-SNAPSHOT.
  - Migrates dependencies from javax.* to jakarta.* counterparts.
- Refactors imports in McpApiManager to use jakarta packages.
- Streamlines several switch expressions and conditional blocks for conciseness.