### PR TITLE
Improve documentation, search output format, and test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,20 @@
+# Maven
 /target/
-/work/
-/bin/
-/mydbflute/
-/solr/data/
-/src/main/webapp/WEB-INF/classes/
-/src/main/webapp/WEB-INF/lib/
-/src/main/webapp/jar/
-/dbflute_fess/log/*.log
-/dbflute_h2/log/*.log
-/dbflute_mysql/log/*.log
-/dbflute_oracle/log/*.log
-/src/main/webapp/WEB-INF/conf/*.properties
-/src/main/webapp/WEB-INF/db/*.lock.db
-/src/main/webapp/WEB-INF/logs/fess*
+
+# IDE - Eclipse
 /.settings/
 .project
 .classpath
+
+# IDE - IntelliJ IDEA
 *.iml
-.idea
+.idea/
+
+# IDE - VS Code
+.vscode/
+
+# OS
 .DS_Store
-/plugins/
-/tomcat.8080/
+
+# Serena
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Maven-based Java plugin for Fess that provides a JSON-RPC 2.0 compliant MCP (Model Context Protocol) API. The plugin enables JSON-RPC-based interactions for executing search and administrative commands through Fess's search engine capabilities.
+
+## Development Commands
+
+### Build and Package
+```bash
+mvn clean package
+```
+
+### Run Tests
+```bash
+mvn test
+```
+
+### Run a Single Test
+```bash
+mvn test -Dtest=McpApiManagerTest
+mvn test -Dtest=McpApiManagerTest#testHandleInitialize
+```
+
+### Code Formatting
+```bash
+mvn formatter:format
+```
+
+## Architecture
+
+### Core Components
+
+- **McpApiManager** (`src/main/java/.../api/mcp/McpApiManager.java`): Main API manager extending BaseApiManager, handles JSON-RPC 2.0 requests at `/mcp/*` endpoints. This is the central class containing all MCP protocol handlers.
+
+- **McpApiException** (`src/main/java/.../exception/McpApiException.java`): Custom exception for MCP API errors with ErrorCode support.
+
+- **ErrorCode** (`src/main/java/.../mcp/ErrorCode.java`): Enum defining standard JSON-RPC error codes (-32700, -32600, -32601, -32602, -32603).
+
+### Plugin Registration
+
+The plugin is registered through DI configuration in `src/main/resources/fess_api++.xml`, which registers the McpApiManager component with Fess's WebApiManagerFactory.
+
+### MCP Protocol Methods
+
+The API supports these JSON-RPC methods:
+- `initialize` - Returns server capabilities and metadata
+- `tools/list` - Lists available tools (search, get_index_stats)
+- `tools/call` - Executes tools with parameters
+- `resources/list` - Lists available resources
+- `prompts/list` - Lists available prompts
+
+### Search Integration
+
+Search functionality integrates with Fess through SearchHelper and SearchRenderData. Query syntax is similar to Lucene (AND default, OR explicit, phrase search with quotes, exclusion with -).
+
+### Configuration
+
+- System property `mcp.content.max.length` controls content truncation (default: 10000 characters)
+
+## Key Dependencies
+
+- Fess search engine framework (provided scope)
+- OpenSearch for search operations
+- LastaFlute web framework
+- Jakarta EE APIs (Servlet, Annotation)

--- a/src/main/java/org/codelibs/fess/plugin/webapp/exception/McpApiException.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/exception/McpApiException.java
@@ -19,24 +19,43 @@ import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.plugin.webapp.mcp.ErrorCode;
 
 /**
- * Exception thrown when an invalid query is encountered in the MCP API.
+ * Exception thrown when an error occurs in the MCP API.
  */
 public class McpApiException extends FessSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /** The JSON-RPC error code. */
     private ErrorCode code;
 
+    /**
+     * Creates an MCP API exception with the specified error code and message.
+     *
+     * @param code    the JSON-RPC error code
+     * @param message the error message
+     */
     public McpApiException(final ErrorCode code, final String message) {
         super(message);
         this.code = code;
     }
 
+    /**
+     * Creates an MCP API exception with the specified error code, message, and cause.
+     *
+     * @param code    the JSON-RPC error code
+     * @param message the error message
+     * @param cause   the cause of this exception
+     */
     public McpApiException(final ErrorCode code, final String message, final Throwable cause) {
         super(message, cause);
         this.code = code;
     }
 
+    /**
+     * Returns the JSON-RPC error code.
+     *
+     * @return the error code
+     */
     public ErrorCode getCode() {
         return code;
     }

--- a/src/main/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCode.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCode.java
@@ -15,16 +15,38 @@
  */
 package org.codelibs.fess.plugin.webapp.mcp;
 
+/**
+ * Standard JSON-RPC 2.0 error codes for MCP API.
+ */
 public enum ErrorCode {
-    // Standard JSON-RPC error codes
-    ParseError(-32700), InvalidRequest(-32600), MethodNotFound(-32601), InvalidParams(-32602), InternalError(-32603);
+    /** Parse error: Invalid JSON was received by the server. */
+    ParseError(-32700),
+    /** Invalid Request: The JSON sent is not a valid Request object. */
+    InvalidRequest(-32600),
+    /** Method not found: The method does not exist or is not available. */
+    MethodNotFound(-32601),
+    /** Invalid params: Invalid method parameter(s). */
+    InvalidParams(-32602),
+    /** Internal error: Internal JSON-RPC error. */
+    InternalError(-32603);
 
+    /** The numeric error code. */
     private final int code;
 
+    /**
+     * Creates an ErrorCode with the specified numeric code.
+     *
+     * @param code the numeric error code
+     */
     ErrorCode(final int code) {
         this.code = code;
     }
 
+    /**
+     * Returns the numeric error code.
+     *
+     * @return the error code
+     */
     public int getCode() {
         return code;
     }

--- a/src/test/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCodeTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCodeTest.java
@@ -114,8 +114,8 @@ public class ErrorCodeTest {
         expectedCodes.put(ErrorCode.InternalError, -32603);
 
         for (final java.util.Map.Entry<ErrorCode, Integer> entry : expectedCodes.entrySet()) {
-            assertEquals("Error code " + entry.getKey().name() + " should have correct value",
-                    entry.getValue().intValue(), entry.getKey().getCode());
+            assertEquals("Error code " + entry.getKey().name() + " should have correct value", entry.getValue().intValue(),
+                    entry.getKey().getCode());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project overview, development commands, and architecture documentation for Claude Code integration
- Improve search tool description with query syntax information (AND, OR, phrase search, exclusion)
- Refactor search response to return documents in Markdown format with configurable content truncation (`mcp.content.max.length` system property)
- Add Javadoc comments to McpApiManager, McpApiException, and ErrorCode classes
- Clean up .gitignore to remove unused entries and add common IDE/OS ignores
- Add comprehensive unit tests for new functionality

## Test plan
- [x] Run `mvn test` to verify all tests pass
- [ ] Verify search responses are properly formatted in Markdown
- [ ] Test content truncation with various `mcp.content.max.length` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)