### PR TITLE
Change default num parameter to 3 for search tool

### DIFF
--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManager.java
@@ -216,7 +216,7 @@ public class McpApiManager extends BaseApiManager {
         searchProperties.put("q", Map.of("type", "string", "description", "query string"));
         searchProperties.put("start", Map.of("type", "integer", "description", "start position"));
         searchProperties.put("offset", Map.of("type", "integer", "description", "offset (alias of start)"));
-        searchProperties.put("num", Map.of("type", "integer", "description", "number of results"));
+        searchProperties.put("num", Map.of("type", "integer", "description", "number of results (default: 3)"));
         searchProperties.put("sort", Map.of("type", "string", "description", "sort order"));
         searchProperties.put("fields.label", Map.of("type", "array", "description", "labels to return"));
         searchProperties.put("lang", Map.of("type", "string", "description", "language"));
@@ -381,7 +381,7 @@ public class McpApiManager extends BaseApiManager {
                 } catch (final NumberFormatException e) {
                     logger.debug("Failed to parse {}", value, e);
                 }
-                return fessConfig.getPagingSearchPageSizeAsInteger();
+                return 3;
             }
 
             @Override

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManagerTest.java
@@ -1151,4 +1151,27 @@ public class McpApiManagerTest {
         final String result = mcpApiManager.truncateContent(content, 0);
         assertEquals("Zero max length should return ...", "...", result);
     }
+
+    @Test
+    public void testHandleListTools_NumParameterDefaultDescription() {
+        final Map<String, Object> result = mcpApiManager.handleListTools();
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, Object>> tools = (List<Map<String, Object>>) result.get("tools");
+        final Map<String, Object> searchTool = tools.get(0);
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> searchSchema = (Map<String, Object>) searchTool.get("inputSchema");
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> searchProperties = (Map<String, Object>) searchSchema.get("properties");
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> numProperty = (Map<String, Object>) searchProperties.get("num");
+        assertNotNull("num property should exist", numProperty);
+
+        final String numDescription = (String) numProperty.get("description");
+        assertNotNull("num description should not be null", numDescription);
+        assertTrue("num description should contain default value", numDescription.contains("default: 3"));
+    }
 }


### PR DESCRIPTION
## Summary

- Update the search tool's default number of results from the configured page size to a fixed value of 3
- Update the `num` parameter description to include the default value: `(default: 3)`
- Add test to verify the parameter description includes the default value

This change makes the default more appropriate for MCP tool usage, where smaller result sets are typically preferred.

## Test plan

- [x] Unit test added for verifying the num parameter description
- [ ] Verify search tool returns 3 results by default when num is not specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)