### PR TITLE
Enhance get_index_stats tool with detailed statistics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,9 @@ The API supports these JSON-RPC methods:
 - `tools/list` - Lists available tools (search, get_index_stats)
 - `tools/call` - Executes tools with parameters
 - `resources/list` - Lists available resources
+- `resources/read` - Reads resource content by URI
 - `prompts/list` - Lists available prompts
+- `prompts/get` - Gets prompt messages with arguments substituted
 
 ### Search Integration
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ Execute a specific tool.
     "content": [
       {
         "type": "text",
-        "text": "{\"q\":\"elasticsearch\",\"query_id\":\"...\",\"exec_time\":42,\"page_size\":10,\"record_count\":25,\"data\":[...]}"
+        "text": "**Title**: Introduction to Elasticsearch\n**URL**: https://example.com/elasticsearch-intro\n**Score**: 1.234\n\nElasticsearch is a distributed, RESTful search and analytics engine..."
+      },
+      {
+        "type": "text",
+        "text": "**Title**: Elasticsearch Tutorial\n**URL**: https://example.com/es-tutorial\n**Score**: 1.123\n\nLearn how to use Elasticsearch for full-text search..."
       }
     ]
   }
@@ -220,7 +224,40 @@ List available resources.
 }
 ```
 
-### 5. prompts/list
+### 5. resources/read
+
+Read a specific resource by URI.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "resources/read",
+  "params": {
+    "uri": "fess://index/stats"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "contents": [
+      {
+        "uri": "fess://index/stats",
+        "mimeType": "application/json",
+        "text": "{\"index_name\":\"fess.search\",\"document_count\":1234,\"store_size\":\"10mb\",...}"
+      }
+    ]
+  }
+}
+```
+
+### 6. prompts/list
 
 List available prompts.
 
@@ -228,9 +265,75 @@ List available prompts.
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 6,
+  "id": 7,
   "method": "prompts/list",
   "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "prompts": [
+      {
+        "name": "basic_search",
+        "description": "Perform a basic search with a query string",
+        "arguments": [
+          {"name": "query", "description": "The search query", "required": true}
+        ]
+      },
+      {
+        "name": "advanced_search",
+        "description": "Perform an advanced search with filters and sorting",
+        "arguments": [
+          {"name": "query", "description": "The search query", "required": true},
+          {"name": "sort", "description": "Sort order", "required": false},
+          {"name": "num", "description": "Number of results to return", "required": false}
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 7. prompts/get
+
+Get a prompt with arguments substituted.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "prompts/get",
+  "params": {
+    "name": "basic_search",
+    "arguments": {
+      "query": "machine learning"
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please search for: machine learning"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -243,7 +346,7 @@ The `search` tool supports the following parameters:
 | `q` | string | Yes | Query string for full-text search |
 | `start` | integer | No | Start position for pagination (default: 0) |
 | `offset` | integer | No | Alias for start position |
-| `num` | integer | No | Number of results to return (default: 10) |
+| `num` | integer | No | Number of results to return (default: 3) |
 | `sort` | string | No | Sort order (e.g., "score.desc", "last_modified.desc") |
 | `fields.label` | array | No | Specific labels to filter by |
 | `lang` | string | No | Language filter |

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/mcp/McpApiManagerTest.java
@@ -1153,7 +1153,7 @@ public class McpApiManagerTest {
     }
 
     @Test
-    public void testHandleListTools_NumParameterDefaultDescription() {
+    public void testHandleListTools_NumParameterDefaultValue() {
         final Map<String, Object> result = mcpApiManager.handleListTools();
 
         @SuppressWarnings("unchecked")
@@ -1172,6 +1172,128 @@ public class McpApiManagerTest {
 
         final String numDescription = (String) numProperty.get("description");
         assertNotNull("num description should not be null", numDescription);
-        assertTrue("num description should contain default value", numDescription.contains("default: 3"));
+        assertEquals("number of results", numDescription);
+
+        final Object defaultValue = numProperty.get("default");
+        assertNotNull("num default should exist in schema", defaultValue);
+        assertEquals("num default should be 3", 3, defaultValue);
+    }
+
+    // ==================== Index Stats Tests ====================
+
+    @Test
+    public void testCollectIndexStats_RequiresDIContainer() {
+        // collectIndexStats requires ComponentUtil which needs DI container
+        try {
+            mcpApiManager.collectIndexStats();
+            // If container is initialized, we would get a valid result
+            fail("Should fail due to DI container not initialized in unit test");
+        } catch (final IllegalStateException e) {
+            // Expected in unit test when DI container is not initialized
+            assertTrue("Should fail due to container not initialized", e.getMessage().contains("container"));
+        }
+    }
+
+    @Test
+    public void testInvokeGetIndexStats_RequiresDIContainer() {
+        // invokeGetIndexStats requires ComponentUtil which needs DI container
+        try {
+            mcpApiManager.invokeGetIndexStats();
+            // If container is initialized, we would get a valid result
+            fail("Should fail due to DI container not initialized in unit test");
+        } catch (final IllegalStateException e) {
+            // Expected in unit test when DI container is not initialized
+            assertTrue("Should fail due to container not initialized", e.getMessage().contains("container"));
+        }
+    }
+
+    @Test
+    public void testBuildIndexStatsResource_RequiresDIContainer() {
+        // buildIndexStatsResource requires ComponentUtil which needs DI container
+        try {
+            mcpApiManager.buildIndexStatsResource();
+            // If container is initialized, we would get a valid result
+            fail("Should fail due to DI container not initialized in unit test");
+        } catch (final IllegalStateException e) {
+            // Expected in unit test when DI container is not initialized
+            assertTrue("Should fail due to container not initialized", e.getMessage().contains("container"));
+        }
+    }
+
+    @Test
+    public void testDispatchRpcMethod_ToolsCall_GetIndexStats() {
+        // Test tools/call with get_index_stats tool
+        final Map<String, Object> params = new HashMap<>();
+        params.put("name", "get_index_stats");
+        params.put("arguments", Map.of());
+
+        try {
+            mcpApiManager.dispatchRpcMethod("tools/call", params);
+            // If container is initialized, we would get a valid result
+            fail("Should fail due to DI container not initialized in unit test");
+        } catch (final IllegalStateException e) {
+            // Expected in unit test when DI container is not initialized
+            assertTrue("Should fail due to container not initialized", e.getMessage().contains("container"));
+        }
+    }
+
+    @Test
+    public void testHandleInvoke_GetIndexStats() {
+        // Test handleInvoke with get_index_stats tool
+        final Map<String, Object> params = new HashMap<>();
+        params.put("name", "get_index_stats");
+        params.put("arguments", Map.of());
+
+        try {
+            mcpApiManager.handleInvoke(params);
+            // If container is initialized, we would get a valid result
+            fail("Should fail due to DI container not initialized in unit test");
+        } catch (final IllegalStateException e) {
+            // Expected in unit test when DI container is not initialized
+            assertTrue("Should fail due to container not initialized", e.getMessage().contains("container"));
+        }
+    }
+
+    @Test
+    public void testHandleListTools_GetIndexStatsTool() {
+        final Map<String, Object> result = mcpApiManager.handleListTools();
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, Object>> tools = (List<Map<String, Object>>) result.get("tools");
+
+        // Find get_index_stats tool
+        Map<String, Object> indexStatsTool = null;
+        for (final Map<String, Object> tool : tools) {
+            if ("get_index_stats".equals(tool.get("name"))) {
+                indexStatsTool = tool;
+                break;
+            }
+        }
+
+        assertNotNull("get_index_stats tool should exist", indexStatsTool);
+        assertEquals("Tool name should be get_index_stats", "get_index_stats", indexStatsTool.get("name"));
+        assertEquals("Tool description", "Get index statistics and information", indexStatsTool.get("description"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> inputSchema = (Map<String, Object>) indexStatsTool.get("inputSchema");
+        assertNotNull("inputSchema should not be null", inputSchema);
+        assertEquals("inputSchema type should be object", "object", inputSchema.get("type"));
+    }
+
+    @Test
+    public void testHandleListResources_IndexStatsResource() {
+        final Map<String, Object> result = mcpApiManager.handleListResources();
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, Object>> resources = (List<Map<String, Object>>) result.get("resources");
+
+        assertNotNull("resources should not be null", resources);
+        assertEquals("Should have 1 resource", 1, resources.size());
+
+        final Map<String, Object> indexStatsResource = resources.get(0);
+        assertEquals("Resource URI", "fess://index/stats", indexStatsResource.get("uri"));
+        assertEquals("Resource name", "Index Statistics", indexStatsResource.get("name"));
+        assertEquals("Resource mimeType", "application/json", indexStatsResource.get("mimeType"));
+        assertNotNull("Resource should have description", indexStatsResource.get("description"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `collectIndexStats()` method to gather comprehensive index information including document count, configuration, and system memory usage
- Add `default` field to `num` parameter schema for MCP compliance
- Refactor `invokeGetIndexStats()` and `buildIndexStatsResource()` to use shared method
- Add comprehensive unit tests for index stats functionality

## Test plan
- [x] Existing tests pass
- [ ] Manual verification of get_index_stats output with running Fess instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)