### PR TITLE
chore: Update fess-parent version to 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.4.0-SNAPSHOT</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

This PR updates the fess-parent version from 15.4.0-SNAPSHOT to the stable 15.4.0 release version.

## Changes Made

- Updated `pom.xml` parent version from `15.4.0-SNAPSHOT` to `15.4.0`

## Testing

- No functional changes; dependency version update only
- Build should continue to work with the stable release version

## Additional Notes

This change moves from the development snapshot to the official stable release of fess-parent 15.4.0.