### PR TITLE
feat(mcp): enhance logging and improve search result output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This plugin transforms Fess (Enterprise Search Server) into a Model Context Prot
 
 See [Maven Repository](https://repo1.maven.org/maven2/org/codelibs/fess/fess-webapp-mcp/).
 
+## Requirements
+
+- Fess 15.x or later
+- Java 21 or later
+
 ## Installation
 
 1. Download the plugin JAR from the Maven Repository
@@ -250,7 +255,7 @@ Read a specific resource by URI.
       {
         "uri": "fess://index/stats",
         "mimeType": "application/json",
-        "text": "{\"index_name\":\"fess.search\",\"document_count\":1234,\"store_size\":\"10mb\",...}"
+        "text": "{\"index\":{\"index_name\":\"fess.search\",\"document_count\":1234},\"config\":{\"max_page_size\":100},\"system\":{\"memory\":{\"total_bytes\":1073741824,\"free_bytes\":536870912,\"used_bytes\":536870912,\"max_bytes\":2147483648}}}"
       }
     ]
   }
@@ -352,6 +357,17 @@ The `search` tool supports the following parameters:
 | `lang` | string | No | Language filter |
 | `preference` | string | No | Search preference |
 
+### Query Syntax
+
+The search tool supports Lucene-like query syntax:
+
+| Syntax | Description | Example |
+|--------|-------------|---------|
+| `term1 term2` | AND search (default) | `machine learning` |
+| `term1 OR term2` | OR search | `cat OR dog` |
+| `"phrase"` | Phrase search | `"machine learning"` |
+| `-term` | Exclude term | `python -java` |
+
 ## Usage Examples
 
 ### Using curl
@@ -425,6 +441,26 @@ result = response.json()
 print(json.dumps(result, indent=2))
 ```
 
+### Using with Claude Desktop
+
+To use this MCP server with Claude Desktop, add the following configuration to your Claude Desktop config file:
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "fess": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:8080/mcp"]
+    }
+  }
+}
+```
+
+After adding the configuration, restart Claude Desktop to connect to the Fess MCP server.
+
 ## Error Handling
 
 The API returns standard JSON-RPC 2.0 error responses:
@@ -449,6 +485,17 @@ The API returns standard JSON-RPC 2.0 error responses:
 | -32601 | Method not found | The method does not exist |
 | -32602 | Invalid params | Invalid method parameter(s) |
 | -32603 | Internal error | Internal JSON-RPC error |
+
+## Configuration
+
+The following system properties can be configured in Fess:
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `mcp.content.max.length` | 10000 | Maximum length of search result content in characters |
+| `mcp.highlight.fragment.size` | 500 | Size of highlight fragments in characters |
+| `mcp.highlight.num.of.fragments` | 3 | Number of highlight fragments per result |
+| `mcp.default.page.size` | 3 | Default number of search results |
 
 ## Development
 

--- a/src/main/java/org/codelibs/fess/plugin/webapp/exception/McpApiException.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/exception/McpApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 CodeLibs Project and the Others.
+ * Copyright 2012-2025 CodeLibs Project and the Others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCode.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 CodeLibs Project and the Others.
+ * Copyright 2012-2025 CodeLibs Project and the Others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/codelibs/fess/plugin/webapp/exception/McpApiExceptionTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/exception/McpApiExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 CodeLibs Project and the Others.
+ * Copyright 2012-2025 CodeLibs Project and the Others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCodeTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/mcp/ErrorCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 CodeLibs Project and the Others.
+ * Copyright 2012-2025 CodeLibs Project and the Others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Added comprehensive debug logging with `[MCP]` prefix for easier request/response tracing and debugging
- Improved search result output by leveraging `content_description` field with highlight fragments instead of raw truncated content
- Enhanced configuration management by migrating from System.getProperty to FessConfig.getSystemPropertyAsInt

## Changes Made

### Logging Enhancements
- Added detailed debug logging throughout `McpApiManager` with consistent `[MCP]` prefix
- Log incoming requests with method, URI, content type, and remote address
- Log parsed JSON-RPC fields (jsonrpc, method, id, params)
- Log method dispatch, tool invocation, and search execution details
- Differentiate error logging: debug level for client errors, warn level for unexpected system errors

### Search Output Improvements
- Request `content_description` field from search results (highlighted snippets)
- Added `stripHighlightTags()` method to remove `<em>` and `<strong>` HTML tags from highlighted content
- Fall back to truncated raw content when `content_description` is empty
- Added configurable highlight settings via system properties:
  - `mcp.highlight.fragment.size` (default: 500)
  - `mcp.highlight.num.of.fragments` (default: 3)

### Configuration Improvements
- Migrated `getContentMaxLength()` from System.getProperty to FessConfig.getSystemPropertyAsInt
- Added `mcp.default.page.size` system property (default: 3)
- All MCP-related configurations now use consistent FessConfig integration

### Documentation
- Added Requirements section (Fess 15.x, Java 21)
- Added Configuration section with system property reference table
- Added Query Syntax section with Lucene-like query examples
- Added Claude Desktop integration instructions
- Updated resources/read response example with current format

### Other
- Updated copyright year from 2024 to 2025
- Added tests for `stripHighlightTags` and `content_description` handling
- Refactored tests to use `TestMcpApiManager` subclass for better testability

## Testing

- All existing tests pass
- Added new tests for `stripHighlightTags()` method covering:
  - `<em>` tag removal
  - `<strong>` tag removal
  - Mixed tags
  - Null and empty input handling
- Added tests for `createDocumentContent` with `content_description` field
- Added test for content truncation fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)