### PR TITLE
chore: Update fess-parent version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update fess-parent version from 15.5.0-SNAPSHOT to 15.5.0 release.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.5.0-SNAPSHOT` to `15.5.0`

## Testing
- Standard Maven build verification

## Breaking Changes
- None

## Additional Notes
- This aligns the project with the released version of fess-parent